### PR TITLE
Allow websocket monitoring to fail

### DIFF
--- a/client/irma.js
+++ b/client/irma.js
@@ -459,7 +459,11 @@ function handleInitialServerMessage(xhr, scounter) {
 }
 
 function startSession() {
-    setupClientMonitoring();
+    try {
+        setupClientMonitoring();
+    } catch (Err) {
+        log(Loglevel.Info, "Websocket setup failed");
+    }
     setupFallbackMonitoring();
     setupTimeoutMonitoring();
     connectClientToken();

--- a/client/irma.js
+++ b/client/irma.js
@@ -459,11 +459,7 @@ function handleInitialServerMessage(xhr, scounter) {
 }
 
 function startSession() {
-    try {
-        setupClientMonitoring();
-    } catch (Err) {
-        log(Loglevel.Info, "Websocket setup failed");
-    }
+    setupClientMonitoring();
     setupFallbackMonitoring();
     setupTimeoutMonitoring();
     connectClientToken();
@@ -474,7 +470,11 @@ function startSession() {
 
 function setupClientMonitoring() {
     var url = apiServer.replace(/^http/, "ws") + "status/" + sessionId;
-    statusWebsocket = new WebSocket(url);
+    try {
+        statusWebsocket = new WebSocket(url);
+    } catch (Err) {
+        log(Loglevel.Info, "Websocket setup failed");
+    }
     statusWebsocket.onmessage = receiveStatusMessage;
 }
 


### PR DESCRIPTION
There are numerous reasons the websocket can fail (proxies, invalid urls, etc). The fallback should then continue. Currently an error can be raised from the websocket initialization, preventing the fallback to initialize.